### PR TITLE
aer-inject, SPEC: Fix spelling mistakes

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -11,7 +11,7 @@ only happens on the software level and does not simulate full PCIE AER
 handling on the platform level.
 
 The PCIE AER error to be injected are described in an input language
-which reflects PCIE AER related registers quite straighforward.
+which reflects PCIE AER related registers quite straightforward.
 
 See the PCI Express Base Specification section 7.10 for details on
 PCIE AER related registers.
@@ -34,10 +34,10 @@ command:
 
   Where
 
-     WWWW is the domain (segment) in hexidecimal (optional)
-     XX is the bus number in hexidecimal
-     YY is the device number in hexidecimal
-     Z is the function number in hexidecimal
+     WWWW is the domain (segment) in hexadecimal (optional)
+     XX is the bus number in hexadecimal
+     YY is the device number in hexadecimal
+     Z is the function number in hexadecimal
 
 Alternatively, you can use:
 

--- a/aer-inject.c
+++ b/aer-inject.c
@@ -39,7 +39,7 @@ void usage(const char *prgname)
 "\n"
 "  PCI_ID       The [<domain>:]<bus>:<slot>.<func> of the device in\n"
 "               hex (same as lspci)\n"
-"  FILE         Error data file (use stdin if ommitted)\n"
+"  FILE         Error data file (use stdin if omitted)\n"
 	       , prgname, prgname, prgname);
 }
 


### PR DESCRIPTION
There are a handful of spelling mistakes, one in the help information and a few in the SPEC file. Fix these.